### PR TITLE
Added set methods and 2 tests for both book and movie

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -19,29 +19,30 @@ public abstract class Book implements StoreMediaOperations {
         this.author = anotherBook.author;
     }
 
+    public void setId(UUID id) { this.id = id; }
+    public void setTitle(String title) { this.title = title; }
+    public void setAuthor(String author) { this.author = author; }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
         }
-
         if (!(obj instanceof Book)) {
             return false;
         }
-
         Book theOtherBook = (Book) obj;
-
 
         // bug is here
         // Quiz: add unit tests to catch this bug.
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+        //        author.equals(theOtherBook.author) &&
+        //        title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+        return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/BookFiction.java
+++ b/src/main/java/Problem3/BookFiction.java
@@ -17,6 +17,8 @@ public class BookFiction extends Book {
         this.genres = anotherBook.genres;
     }
 
+    public void setGenres(String genres) { this.genres = genres; }
+
     @Override
     public int getLateFeeInDollar() {
         return lateFeePerDayInDollar;

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -19,17 +19,18 @@ public abstract class Movie implements StoreMediaOperations {
         this.id = anotherMovie.id;
     }
 
+    public void setRating(String rating) { this.rating = rating; }
+    public void setTitle(String title) { this.title = title; }
+    public void setId(UUID id) { this.id = id; }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
             return true;
         }
-
         if (!(obj instanceof Movie)) {
             return false;
         }
-
-
         Movie theOtherMovie = (Movie) obj;
 
         // bug is here
@@ -37,11 +38,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+        //        rating.equals(theOtherMovie.rating) &&
+        //        title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -1,17 +1,37 @@
 import Problem3.*;
 import org.junit.Test;
 
+import java.util.UUID;
+
 import static org.junit.Assert.*;
 
 public class Problem3Test {
     @Test
-    public void catchTheBugInBook() {
-        // quiz
+    public void catchTheBugInBook()
+    {
+        BookFiction a = new BookFiction("A", "Me", "SciFi");
+        BookFiction b = new BookFiction(a);
+        b.setGenres("Fantasy");
+        assertTrue(a.equals(b));
+
+        BookRomance c = new BookRomance("Romeo", "Shake");
+        BookRomance d = new BookRomance(c);
+        c.setAuthor("Shakespeare");
+        assertTrue(c.equals(d));
     }
 
     @Test
-    public void catchTheBugInMovie() {
-        // quiz
+    public void catchTheBugInMovie()
+    {
+        MovieAction a = new MovieAction("PG13", "Revengers");
+        MovieAction b = new MovieAction(a);
+        b.setTitle("Revengers: Age of Altron");
+        assertTrue(a.equals(b));
+
+        MovieComedy c = new MovieComedy("E","Dumb Dumber");
+        MovieComedy d = new MovieComedy(c);
+        d.setRating("PG");
+        assertTrue(c.equals(d));
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
All the tests we already have where we test the equals function do not differentiate between UUID and the other variables of a book or movie. I mean that if the UUID of two of the object are equal within our tests, the title and author/rating are also equal. This bug would fail if we had for example, a book with UUID 123 and title “A” and compared it to a book with UUID 123 but title “B”. 